### PR TITLE
UnlimitedIntMetadataProperty::write now using ByteBufferWriter

### DIFF
--- a/src/entity/utils/UnlimitedIntMetadataProperty.php
+++ b/src/entity/utils/UnlimitedIntMetadataProperty.php
@@ -22,11 +22,13 @@
 declare(strict_types=1);
 namespace pocketmine\entity\utils;
 
+use InvalidArgumentException;
 use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataTypes;
 use pocketmine\network\mcpe\protocol\types\entity\IntegerishMetadataProperty;
 use pocketmine\network\mcpe\protocol\types\entity\MetadataProperty;
 use pocketmine\network\mcpe\protocol\types\GetTypeIdFromConstTrait;
+use pmmp\encoding\ByteBufferWriter;
 use const PHP_INT_MAX;
 use const PHP_INT_MIN;
 
@@ -47,7 +49,33 @@ final class UnlimitedIntMetadataProperty implements MetadataProperty {
 		return new self($in->getVarInt());
 	}
 
+	/* Outdated due to ext-encoding MetadataProperty now requiring ByteBufferWriter for write(..)
 	public function write(PacketSerializer $out) : void{
 		$out->putVarInt($this->value);
 	}
+	*/
+
+	public function write(ByteBufferWriter $out) : void{
+		// Zigzag-encode 32-bit signed int, then write as unsigned VarInt (max 5 bytes)
+		$v = $this->value;
+		$u = (($v << 1) ^ ($v >> 31));     // zigzag to unsigned
+		$remaining = $u & 0xffffffff;      // constrain to 32-bit like Binary::writeUnsignedVarInt()
+
+		for($i = 0; $i < 5; ++$i){
+			if(($remaining >> 7) !== 0){
+				// write low 7 bits with continuation flag
+				$out->writeByteArray(chr(($remaining & 0xFF) | 0x80));
+			}else{
+				// last byte, no continuation
+				$out->writeByteArray(chr($remaining & 0x7F));
+				return;
+			}
+			// logical right shift by 7; PHP has only arithmetic >>, so mask
+			$remaining = (($remaining >> 7) & (PHP_INT_MAX >> 6));
+		}
+
+		// Should never happen for 32-bit values
+		throw new InvalidArgumentException("Value too large to be encoded as a VarInt");
+	}
+
 }

--- a/src/entity/utils/UnlimitedIntMetadataProperty.php
+++ b/src/entity/utils/UnlimitedIntMetadataProperty.php
@@ -22,13 +22,14 @@
 declare(strict_types=1);
 namespace pocketmine\entity\utils;
 
-use InvalidArgumentException;
+use pmmp\encoding\ByteBufferReader;
+use pmmp\encoding\ByteBufferWriter;
+use pmmp\encoding\VarInt;
 use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataTypes;
 use pocketmine\network\mcpe\protocol\types\entity\IntegerishMetadataProperty;
 use pocketmine\network\mcpe\protocol\types\entity\MetadataProperty;
 use pocketmine\network\mcpe\protocol\types\GetTypeIdFromConstTrait;
-use pmmp\encoding\ByteBufferWriter;
 use const PHP_INT_MAX;
 use const PHP_INT_MIN;
 
@@ -45,8 +46,8 @@ final class UnlimitedIntMetadataProperty implements MetadataProperty {
 		return PHP_INT_MAX;
 	}
 
-	public static function read(PacketSerializer $in) : self{
-		return new self($in->getVarInt());
+	public static function read(ByteBufferReader $in) : self{
+		return new self(VarInt::readSignedInt($in));
 	}
 
 	/* Outdated due to ext-encoding MetadataProperty now requiring ByteBufferWriter for write(..)
@@ -56,26 +57,7 @@ final class UnlimitedIntMetadataProperty implements MetadataProperty {
 	*/
 
 	public function write(ByteBufferWriter $out) : void{
-		// Zigzag-encode 32-bit signed int, then write as unsigned VarInt (max 5 bytes)
-		$v = $this->value;
-		$u = (($v << 1) ^ ($v >> 31));     // zigzag to unsigned
-		$remaining = $u & 0xffffffff;      // constrain to 32-bit like Binary::writeUnsignedVarInt()
-
-		for($i = 0; $i < 5; ++$i){
-			if(($remaining >> 7) !== 0){
-				// write low 7 bits with continuation flag
-				$out->writeByteArray(chr(($remaining & 0xFF) | 0x80));
-			}else{
-				// last byte, no continuation
-				$out->writeByteArray(chr($remaining & 0x7F));
-				return;
-			}
-			// logical right shift by 7; PHP has only arithmetic >>, so mask
-			$remaining = (($remaining >> 7) & (PHP_INT_MAX >> 6));
-		}
-
-		// Should never happen for 32-bit values
-		throw new InvalidArgumentException("Value too large to be encoded as a VarInt");
+		VarInt::writeSignedInt($out, $this->value);
 	}
 
 }


### PR DESCRIPTION
<!-- Summarize your PR here. Keep it short and simple. -->
Fix `UnlimitedIntMetadataProperty::write()` to match the new `MetadataProperty` interface and encoding path:
- Change parameter type to `pmmp\encoding\ByteBufferWriter`.
- Write the value using **zigzag VarInt** (bit-for-bit equivalent to `PacketSerializer::putVarInt()`), not plain unsigned LEB128.

This resolves a compile-time interface mismatch and fixes incorrect FallingBlock VARIANT runtime IDs.

### Related issues & PRs
* Fixes: crash on spawn for `FallingBlock` due to `UnlimitedIntMetadataProperty::write()` signature mismatch.
* Fixes: wrong block runtime ID sent for `FallingBlock` metadata (VARIANT).

## Changes
### API changes
- None exposed to plugins. This aligns an internal implementation with the core interface (`MetadataProperty::write(ByteBufferWriter $out): void`).

### Behavioural changes
- Falling blocks (e.g., sand/gravel) now:
  - Spawn without `E_COMPILE_ERROR`.
  - Send the correct VARIANT block runtime ID across protocols.

## Backwards compatibility
- No breaking changes to public APIs.
- Internal only: changes the `write()` signature to the new encoding writer and corrects the VarInt encoding to zigzag.

## Follow-up
- (Optional) Update `UnlimitedIntMetadataProperty::read()` to use `ByteBufferReader` when the corresponding read-side interface is migrated.
- Audit other `MetadataProperty` implementations to ensure they use `ByteBufferWriter`/`ByteBufferReader` and zigzag VarInt where appropriate.

## Tests
**Manual:**
1. Run server from source with this patch.
2. In Creative, place sand over air (or use commands to spawn `FALLING_BLOCK`).
3. Observe:
   - No fatal error on spawn.
   - Client renders the correct block type for the falling block.
   - (If logging) Confirm `write()` is hit and the encoded bytes match `Binary::writeVarInt($value)`.

**Verification snippet used inside `write()` (for reviewers):**
```php
public function write(\pmmp\encoding\ByteBufferWriter $out) : void{
    $v = $this->value;
    $u = (($v << 1) ^ ($v >> 31));        // zigzag
    $remaining = $u & 0xffffffff;         // mirror Binary::writeUnsignedVarInt()

    for($i = 0; $i < 5; ++$i){
        if(($remaining >> 7) !== 0){
            $out->writeByteArray(chr(($remaining & 0xFF) | 0x80));
        }else{
            $out->writeByteArray(chr($remaining & 0x7F));
            return;
        }
        $remaining = (($remaining >> 7) & (PHP_INT_MAX >> 6));
    }
    throw new \InvalidArgumentException("Value too large to be encoded as a VarInt");
}
